### PR TITLE
docs: Mark project as paused

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # OpenTUI.NET
 
+> ⚠️ **Status: Paused** - This was a learning project. For production TUI apps in C#, we recommend [Hex1b](https://github.com/mitchdenny/hex1b) which provides similar capabilities with better maturity.
+
 A pure C# terminal UI library with flexbox layout, inspired by [OpenTUI](https://github.com/anomalyco/opentui). Build rich, interactive terminal applications with a React-like component model. 
 
-This is experimental right now and written using GitHub Copilot CLI.
-I do not recommend this to be taken as a dependency by **anyone** until this gets more end-end-end validation and code review. 
+This is experimental and was written using GitHub Copilot CLI as a learning exercise. 
 
 [![.NET](https://img.shields.io/badge/.NET-10.0-512BD4)](https://dotnet.microsoft.com/)
 [![License](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)


### PR DESCRIPTION
Updates README to indicate project is paused and recommends Hex1b as the production-ready alternative for C# TUI development.